### PR TITLE
Renormalize weights if a calculator returns nil

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 **.DS_Store
 Guardfile
 Gemfile.lock
+vendor/cache
+.ruby-gemset
+.ruby-version
+pkg/

--- a/README.md
+++ b/README.md
@@ -19,15 +19,16 @@ _Note: weights are assumed to be equal if not provided_
 
 #API
 
-##Describe the field calculators
+##Describe the field distance calculators
 
 Each field to be considered in the distance calculation should be described 
 with a calculation method and weight(optional)
 
 Valid calculators:
 
-* day_of_month (this needs to be factored into configurable date_recurrence)
-* float_range_distance
+* day_of_year
+* day_of_month
+* levenshtein
 
 ```ruby
 distance_rules = {
@@ -81,3 +82,9 @@ matcher.closest_match(candidate, [example, example2], 0.2)
 => example
 
 ```
+
+# To Do
+
+* Add more field distance calculators
+
+

--- a/spec/slide_rule/distance_calculator_spec.rb
+++ b/spec/slide_rule/distance_calculator_spec.rb
@@ -19,6 +19,12 @@ describe ::SlideRule::DistanceCalculator do
     end
   end
 
+  class NilCalc
+    def calculate(_first, _second)
+      nil
+    end
+  end
+
   let(:examples) do
     [
       ::ExampleTransaction.new(amount: 25.00,   date: '2015-02-05', description: 'Audible.com'),
@@ -95,6 +101,22 @@ describe ::SlideRule::DistanceCalculator do
         #   = 0.2318181818181818
         distance = calculator.calculate_distance(example, candidate)
         expect(distance.round(4)).to eq(((3.0 * 0.5 / 15) + (4.0 * 0.5 / 11)).round(4))
+      end
+
+      it 'should renormalize on nil' do
+        calculator = ::SlideRule::DistanceCalculator.new(
+          description: {
+            weight: 0.50,
+            type: :levenshtein
+          },
+          date: {
+            weight: 0.50,
+            type: NilCalc
+          }
+        )
+        example1 = ::ExampleTransaction.new(amount: 25.00, date: '2015-02-05', description: 'Audible.com')
+        example2 = ::ExampleTransaction.new(amount: 25.00, date: '2015-06-08', description: 'Audible Inc')
+        expect(calculator.calculate_distance(example1, example2).round(4)).to eq((4.0 / 11).round(4))
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,7 @@
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 
 require_relative '../lib/slide_rule.rb'
+require 'pry'
 
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate


### PR DESCRIPTION
If a calculator returns nil, its distance should be ignored. In order to do that correctly, the weights need to be renormalized ignoring the weight of the nil-distance field.

@fergmastaflex 
