### PR TITLE
Change :type to :calculator in rule definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ Valid calculators:
 distance_rules = {
   :description => {
     :weight => 0.80,
-    :type => :levenshtein,
+    :calculator => :levenshtein,
   },
   :date => {
     :weight => 0.90,
-    :type => :day_of_month,
+    :calculator => :day_of_month,
   },
 }
 ```
@@ -82,6 +82,38 @@ matcher.closest_match(candidate, [example, example2], 0.2)
 => example
 
 ```
+
+## Custom Field Distance Calculators
+
+To define a custom field distance calculator, define a class with a `calculate(value1, value2)` method.
+
+Requirements:
+* Class must be stateless
+* Calculate should return a float from `0` (perfect match) to `1.0` (no match)
+* Calculation should not be order dependent (e.g. `calculate(a, b) == calculate(b, a)`)
+
+```ruby
+class StringLengthCalculator
+  def calculate(l1, l2)
+    diff = (l1 - l2).abs.to_f
+    return diff / [l1, l2].max
+  end
+end
+
+matcher = ::SlideRule::DistanceCalculator.new(
+  :length => {
+    :weight => 1.0,
+    :calculator => StringLengthCalculator
+  }
+)
+
+# Find the string with the closest length
+matcher.closest_match("Howdy Doody Time!", ["Felix the cat", "Mighty Mouse"], 0.5)
+# => { :item=>"Mighty Mouse", :distance=>0.29411764705882354 }
+```
+
+See the [distance_calculators](https://github.com/mattnichols/slide_rule/tree/master/lib/slide_rule/distance_calculators) directory in source for more examples.
+
 
 # To Do
 

--- a/spec/slide_rule/distance_calculator_spec.rb
+++ b/spec/slide_rule/distance_calculator_spec.rb
@@ -42,11 +42,11 @@ describe ::SlideRule::DistanceCalculator do
       ::SlideRule::DistanceCalculator.new(
         description: {
           weight: 0.80,
-          type: :levenshtein
+          calculator: :levenshtein
         },
         date: {
           weight: 0.90,
-          type: :day_of_month
+          calculator: :day_of_month
         }
       )
     end
@@ -66,11 +66,11 @@ describe ::SlideRule::DistanceCalculator do
         calculator = ::SlideRule::DistanceCalculator.new(
           description: {
             weight: 1.00,
-            type: :levenshtein
+            calculator: :levenshtein
           },
           date: {
             weight: 0.50,
-            type: :day_of_month
+            calculator: :day_of_month
           }
         )
         example = ::ExampleTransaction.new(amount: 25.00, date: '2015-02-05', description: 'Audible.com')
@@ -82,11 +82,11 @@ describe ::SlideRule::DistanceCalculator do
         calculator = ::SlideRule::DistanceCalculator.new(
           description: {
             weight: 0.50,
-            type: :levenshtein
+            calculator: :levenshtein
           },
           date: {
             weight: 0.50,
-            type: :day_of_month
+            calculator: :day_of_month
           }
         )
         example = ::ExampleTransaction.new(amount: 25.00, date: '2015-02-05', description: 'Audible.com')
@@ -107,15 +107,16 @@ describe ::SlideRule::DistanceCalculator do
         calculator = ::SlideRule::DistanceCalculator.new(
           description: {
             weight: 0.50,
-            type: :levenshtein
+            calculator: :levenshtein
           },
           date: {
             weight: 0.50,
-            type: NilCalc
+            calculator: NilCalc
           }
         )
         example1 = ::ExampleTransaction.new(amount: 25.00, date: '2015-02-05', description: 'Audible.com')
         example2 = ::ExampleTransaction.new(amount: 25.00, date: '2015-06-08', description: 'Audible Inc')
+
         expect(calculator.calculate_distance(example1, example2).round(4)).to eq((4.0 / 11).round(4))
       end
     end
@@ -125,7 +126,7 @@ describe ::SlideRule::DistanceCalculator do
         calculator = ::SlideRule::DistanceCalculator.new(
           description: {
             weight: 1.00,
-            type: CustomCalc
+            calculator: CustomCalc
           }
         )
         example = ::ExampleTransaction.new
@@ -133,6 +134,28 @@ describe ::SlideRule::DistanceCalculator do
 
         distance = calculator.calculate_distance(example, candidate)
         expect(distance).to eq(0.9)
+      end
+    end
+
+    context 'validates rules on initialize' do
+      it 'should allow :type' do
+        ::SlideRule::DistanceCalculator.new(
+          description: {
+            weight: 1.00,
+            type: CustomCalc
+          }
+        )
+      end
+
+      it 'should raise error if not valid calculator' do
+        expect do
+          ::SlideRule::DistanceCalculator.new(
+            description: {
+              weight: 1.00,
+              calculator: :some_junk
+            }
+          )
+        end.to raise_error
       end
     end
   end


### PR DESCRIPTION
:type is a confusing name. This marks :type as deprecated and adds :calculator. Also streamlines calculator creation. Instead of creating a new calculator every time they are needed, create an instance of the calculator on initialization. This requires that calculators be stateless and thread safe.
