### PR TITLE
closest_match bug fix, default threshold and new closest_matching_item method

### DIFF
--- a/lib/slide_rule/distance_calculator.rb
+++ b/lib/slide_rule/distance_calculator.rb
@@ -26,6 +26,13 @@ module SlideRule
       matches(obj, array, threshold).sort_by { |match| match[:distance] }.first
     end
 
+    def closest_matching_item(obj, array, threshold = 1.0)
+      match = closest_match(obj, array, threshold)
+      return nil if match.nil?
+
+      match[:item]
+    end
+
     def matches(obj, array, threshold)
       array.map do |item|
         distance = calculate_distance(obj, item)

--- a/lib/slide_rule/distance_calculator.rb
+++ b/lib/slide_rule/distance_calculator.rb
@@ -22,14 +22,14 @@ module SlideRule
       end
     end
 
-    def closest_match(obj, array, threshold)
-      matches(obj, array, threshold).sort { |match| match[:distance] }.first
+    def closest_match(obj, array, threshold = 1.0)
+      matches(obj, array, threshold).sort_by { |match| match[:distance] }.first
     end
 
     def matches(obj, array, threshold)
       array.map do |item|
         distance = calculate_distance(obj, item)
-        next nil unless distance < threshold
+        next nil unless distance <= threshold
         {
           item: item,
           distance: distance

--- a/spec/slide_rule/distance_calculator_spec.rb
+++ b/spec/slide_rule/distance_calculator_spec.rb
@@ -51,12 +51,17 @@ describe ::SlideRule::DistanceCalculator do
       )
     end
 
-    it 'finds recurring transaction' do
+    it 'finds closest' do
       example = ExampleTransaction.new(description: 'Wells Fargo Dealer SVC', date: '2015-06-17')
       expect(calculator.closest_match(example, examples, 0.2)[:item]).to eq(examples[3])
 
       example = ExampleTransaction.new(description: 'Audible.com', date: '2015-06-05')
       expect(calculator.closest_match(example, examples, 0.2)[:item]).to eq(examples[0])
+    end
+
+    it 'with default threshold' do
+      example = ExampleTransaction.new(description: 'Audible.com', date: '2015-06-05')
+      expect(calculator.closest_match(example, examples)[:item]).to eq(examples[0])
     end
   end
 

--- a/spec/slide_rule/distance_calculator_spec.rb
+++ b/spec/slide_rule/distance_calculator_spec.rb
@@ -63,6 +63,11 @@ describe ::SlideRule::DistanceCalculator do
       example = ExampleTransaction.new(description: 'Audible.com', date: '2015-06-05')
       expect(calculator.closest_match(example, examples)[:item]).to eq(examples[0])
     end
+
+    it 'finds closest matching item' do
+      example = ExampleTransaction.new(description: 'Audible.com', date: '2015-06-05')
+      expect(calculator.closest_matching_item(example, examples)).to eq(examples[0])
+    end
   end
 
   describe '#calculate_distance' do


### PR DESCRIPTION
Make threshold default to 1.0. Fix nasty bug with closest_match. It was not sorting the matches correctly, resulting in incorrect match.
